### PR TITLE
Update Range Rover Velar generations: Add generational data from Wikipedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Range Rover Velar
 
+This repository contains signal set configurations for the Range Rover Velar, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Range Rover Velar.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,0 +1,17 @@
+references:
+  - "https://en.wikipedia.org/wiki/Range_Rover_Velar"
+
+generations:
+  - name: "First Generation"
+    start_year: 2017
+    end_year: 2022
+    description: "Original Range Rover Velar launched in March 2017. Built on the Jaguar Land Rover iQ[AI] (D7a) platform, sharing components with the Jaguar F-Pace, XF, and XE models. Features a new design language with smoother body lines and a interior with 3 touchscreens."
+    platform: "D7a"
+    notes: ""
+
+  - name: "First Generation (Facelift)"
+    start_year: 2023
+    end_year: null
+    description: "Facelifted version introduced in 2023. Updated exterior styling and interior features including enhanced infotainment system and new engine options."
+    platform: "D7a"
+    notes: ""


### PR DESCRIPTION
- Created generations.yaml with two generation entries
- First Generation (2017-2022): Original launch model
- First Generation Facelift (2023-present): Updated styling and features
- Added Wikipedia reference for Range Rover Velar article
